### PR TITLE
Improve patient signup styling and logic

### DIFF
--- a/lib/features/auth/presentation/pages/patient_signup_page.dart
+++ b/lib/features/auth/presentation/pages/patient_signup_page.dart
@@ -2,7 +2,6 @@ import 'dart:developer';
 
 import 'package:doclib/core/constants/gender_enum.dart';
 import 'package:doclib/core/constants/user_role_enum.dart';
-// import 'package:doclib/core/constants/user_role_enum.dart';
 import 'package:doclib/features/auth/data/models/Auth_model.dart';
 import 'package:doclib/features/auth/presentation/bloc/auth_bloc_bloc.dart';
 import 'package:flutter/material.dart';
@@ -17,71 +16,77 @@ class PatientSignupPage extends StatefulWidget {
 
 class _PatientSignupPageState extends State<PatientSignupPage> {
   late AuthRequest authRequest;
+  final _formKey = GlobalKey<FormState>();
+
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
     authRequest = AuthRequest.nullvalues();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        children: [
-          DropdownButton<GenderEnum>(
+    return BlocListener<AuthBlocBloc, AuthBlocState>(
+      listener: (context, state) {
+        if (state is AuthAuthenticated) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Registered successfully')),
+          );
+        } else if (state is AuthFailed) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.massege)),
+          );
+        }
+      },
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+          DropdownButtonFormField<GenderEnum>(
             value: authRequest.gender,
-            hint: Text('اختر الجنس'),
-            onChanged: (value) => (authRequest.gender = value),
-            items:
-                GenderEnum.values.map((gender) {
-                  return DropdownMenuItem(
-                    value: gender,
-                    child: Text(gender.name),
-                  );
-                }).toList(),
+            decoration: const InputDecoration(labelText: 'Gender'),
+            items: GenderEnum.values
+                .map((gender) => DropdownMenuItem(
+                      value: gender,
+                      child: Text(gender.name),
+                    ))
+                .toList(),
+            onChanged: (value) => setState(() => authRequest.gender = value),
+            validator: (value) => value == null ? 'Required' : null,
           ),
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("firstname"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.firstName = value;
-            },
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'First name'),
+            onChanged: (value) => authRequest.firstName = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("lastname"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.lastName = value;
-            },
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Last name'),
+            onChanged: (value) => authRequest.lastName = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          TextField(
-            onChanged: (value) {
-              authRequest.phoneNumbre = value;
-            },
-
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("phone"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Phone'),
+            keyboardType: TextInputType.phone,
+            onChanged: (value) => authRequest.phoneNumbre = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
           TextFormField(
             readOnly: true,
             decoration: InputDecoration(
               labelText: 'Date of Birth*',
               suffixIcon: const Icon(Icons.calendar_today),
-              hintText:
-                  authRequest.date == null
-                      ? "make it easy"
-                      : authRequest.date!.toIso8601String(),
-
+              hintText: authRequest.date == null
+                  ? 'Pick a date'
+                  : authRequest.date!.toIso8601String(),
               errorStyle: const TextStyle(color: Colors.red),
             ),
             validator: (value) {
@@ -112,69 +117,55 @@ class _PatientSignupPageState extends State<PatientSignupPage> {
             },
           ),
 
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("username"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.username = value;
-            },
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Username'),
+            onChanged: (value) => authRequest.username = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("password"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.password = value;
-            },
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Password'),
+            obscureText: true,
+            onChanged: (value) => authRequest.password = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("addres"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.address = value;
-            },
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Address'),
+            onChanged: (value) => authRequest.address = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          TextField(
-            cursorRadius: Radius.circular(2.0),
-            decoration: InputDecoration(
-              label: Text("email"),
-              constraints: BoxConstraints(maxWidth: 90.0),
-            ),
-            onChanged: (value) {
-              authRequest.email = value;
-            },
+          const SizedBox(height: 12),
+          TextFormField(
+            decoration: const InputDecoration(labelText: 'Email'),
+            keyboardType: TextInputType.emailAddress,
+            onChanged: (value) => authRequest.email = value,
+            validator: (value) =>
+                value == null || value.isEmpty ? 'Required' : null,
           ),
-          IconButton(
+          const SizedBox(height: 20),
+          ElevatedButton(
             onPressed: () {
-              if (authRequest.date != null) {
-                log(authRequest.date.toString());
-              } else {
-                log("shit");
+              if (_formKey.currentState?.validate() ?? false) {
+                final patient = AuthRequest.signupAsPatient(
+                  username: authRequest.username!,
+                  password: authRequest.password!,
+                  firstName: authRequest.firstName!,
+                  gender: authRequest.gender!,
+                  lastName: authRequest.lastName!,
+                  phoneNumber: authRequest.phoneNumbre!,
+                  date: authRequest.date!,
+                  role: UserRoleEnum.patient,
+                  email: authRequest.email!,
+                  address: authRequest.address!,
+                );
+                context.read<AuthBlocBloc>().add(AuthSignUpAsPatietn(patient));
               }
-              final AuthRequest a = AuthRequest.signupAsPatient(
-                username: "@ahmed",
-                password: "password",
-                firstName: "firstName",
-                gender: GenderEnum.male,
-                lastName: "lastName",
-                phoneNumber: "phoneNumber",
-                date: DateTime.now(),
-                role: UserRoleEnum.patient,
-                email: "email",
-                address: "halab wlak",
-              );
-              context.read<AuthBlocBloc>().add(AuthSignUpAsPatietn(a));
-              log(a.toJson().toString(), level: 10);
             },
-            icon: Icon(Icons.check_circle),
+            child: const Text('Sign Up'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- refactor patient signup form UI
- use form validation and bloc listener
- send entered data to signup event

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c40dd8b7c8331adc3ca4d5fb4334c