### PR TITLE
Add error mapping and network checking

### DIFF
--- a/lib/core/errors/error_mapper.dart
+++ b/lib/core/errors/error_mapper.dart
@@ -1,0 +1,25 @@
+import 'package:doclib/core/errors/exeptions.dart';
+import 'package:doclib/core/errors/failure.dart';
+
+/// Maps [AppException]s coming from data sources into their corresponding
+/// [Failure] representation used in the domain layer.
+class ErrorMapper {
+  static Failure map(AppException exception) {
+    switch (exception.runtimeType) {
+      case ServerException:
+        return ServerFailure(exception.message, exception.details);
+      case NetworkException:
+        return NetworkFailure(exception.message, exception.details);
+      case UnauthorizedException:
+        return AuthFailure(exception.message, exception.details);
+      case CacheException:
+        return ServerFailure(exception.message, exception.details);
+      case NotFoundException:
+        return ServerFailure(exception.message, exception.details);
+      case ValidationException:
+        return ServerFailure(exception.message, exception.details);
+      default:
+        return ServerFailure(exception.toString());
+    }
+  }
+}

--- a/lib/core/errors/failure.dart
+++ b/lib/core/errors/failure.dart
@@ -20,7 +20,7 @@ class ServerFailure extends Failure {
 
 class NetworkFailure extends Failure {
   const NetworkFailure([
-    super.mesage = "No internet connection",
+    super.message = "No internet connection",
     super.details,
   ]);
 }

--- a/lib/core/utils/network_checker.dart
+++ b/lib/core/utils/network_checker.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+/// Simple utility to verify network connectivity before performing
+/// remote requests.
+class NetworkChecker {
+  static Future<bool> get isConnected async {
+    try {
+      final result = await InternetAddress.lookup('example.com');
+      return result.isNotEmpty && result[0].rawAddress.isNotEmpty;
+    } on SocketException {
+      return false;
+    }
+  }
+}

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 import 'package:doclib/core/errors/handler.dart';
+import 'package:doclib/core/errors/exeptions.dart';
+import 'package:doclib/core/utils/network_checker.dart';
 import 'package:doclib/features/auth/data/datasources/model_mapper.dart';
 import 'package:doclib/features/auth/data/models/Auth_model.dart';
 import 'package:doclib/features/auth/data/models/user_model.dart';
@@ -23,13 +25,21 @@ class AuthRemoteDataSoureceImpl implements AuthRemoteDataSource {
     log("start sendeing register request ");
     log("auth is${authRequest.toJson().toString()}");
     // print("fofofofofofofofofofofo");
+    if (!await NetworkChecker.isConnected) {
+      throw NetworkException();
+    }
     final url = Uri.parse('http://192.168.137.1:8080/auth/register');
     final body = authRequest.toJson();
-    final response = await client.post(
-      url,
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(body),
-    );
+    late http.Response response;
+    try {
+      response = await client.post(
+        url,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(body),
+      );
+    } on SocketException {
+      throw NetworkException();
+    }
     // final data = {
     //   "id": "20",
     //   "username": "jojo",
@@ -55,13 +65,21 @@ class AuthRemoteDataSoureceImpl implements AuthRemoteDataSource {
 
   @override
   Future<UserModel> login({required AuthRequest authreRuest}) async {
+    if (!await NetworkChecker.isConnected) {
+      throw NetworkException();
+    }
     final url = Uri.parse('http://192.168.1.137:8080/auth/login');
     final body = authreRuest.toJson();
-    final response = await client.post(
-      url,
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(body),
-    );
+    late http.Response response;
+    try {
+      response = await client.post(
+        url,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(body),
+      );
+    } on SocketException {
+      throw NetworkException();
+    }
 
     return handleResponse(response, (json) => UserMapper.fromJson(json));
   }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -2,6 +2,8 @@ import 'dart:developer';
 
 import 'package:dartz/dartz.dart';
 import 'package:doclib/core/errors/failure.dart';
+import 'package:doclib/core/errors/exeptions.dart';
+import 'package:doclib/core/errors/error_mapper.dart';
 import 'package:doclib/features/auth/data/datasources/auth_remote_data_source.dart';
 import 'package:doclib/features/auth/data/models/Auth_model.dart';
 import 'package:doclib/features/auth/domain/entities/user.dart';
@@ -20,8 +22,10 @@ class AuthRepositoryImpl implements AuthRepository {
         authreRuest: authRequest,
       );
       return right(entity.toEntity());
+    } on AppException catch (e) {
+      return left(ErrorMapper.map(e));
     } catch (e) {
-      return left(ServerFailure());
+      return left(ServerFailure(e.toString()));
     }
   }
 
@@ -35,10 +39,10 @@ class AuthRepositoryImpl implements AuthRepository {
       );
       log(entity.runtimeType.toString());
       return right(entity.toEntity());
-    } catch (e, stack) {
-      log(e.toString());
-      // log(entity.runtimeType.toString());
-      return left(NetworkFailure());
+    } on AppException catch (e) {
+      return left(ErrorMapper.map(e));
+    } catch (e) {
+      return left(ServerFailure(e.toString()));
     }
   }
 }


### PR DESCRIPTION
## Summary
- map `AppException` types to `Failure` via new `ErrorMapper`
- provide a simple `NetworkChecker` utility
- check network connectivity and handle `SocketException` in `AuthRemoteDataSource`
- use new mapper in `AuthRepositoryImpl`
- fix typo in `NetworkFailure`

## Testing
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6851e87337d083319e3752d54db0f86f